### PR TITLE
Fix apiRequest argument handling

### DIFF
--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -10,14 +10,24 @@ async function throwIfResNotOk(res: Response) {
 
 export async function apiRequest(
   url: string,
-  options: RequestInit = {},
+  optionsOrMethod: RequestInit | string = {},
+  body?: unknown,
 ): Promise<Response> {
   const apiUrl = buildApiUrl(url);
+
+  const options: RequestInit =
+    typeof optionsOrMethod === "string"
+      ? {
+          method: optionsOrMethod,
+          body: body ? JSON.stringify(body) : undefined,
+        }
+      : optionsOrMethod;
+
   const res = await fetch(apiUrl, {
     ...options,
     headers: {
       "Content-Type": "application/json",
-      ...options.headers,
+      ...(options.headers || {}),
     },
     credentials: "include",
   });


### PR DESCRIPTION
## Summary
- update `apiRequest` to handle URL, method, and body arguments

## Testing
- `npm run check` *(fails: duplicate identifiers and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a51abc8d48326b3b638eb789e1120