### PR TITLE
Add password hashing tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:gh-pages": "vite build",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
+    "test": "tsx --test",
     "db:push": "drizzle-kit push"
   },
   "dependencies": {

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://user:pass@localhost/db';
+const { hashPassword, verifyPassword } = await import('../server/auth');
+
+// Ensure hashing returns a value different from the original
+test('hashPassword returns different value', async () => {
+  const password = 'supersecret';
+  const hash = await hashPassword(password);
+  assert.notStrictEqual(hash, password);
+});
+
+// Ensure verifyPassword validates a correct password
+test('verifyPassword succeeds for valid password/hash', async () => {
+  const password = 'supersecret';
+  const hash = await hashPassword(password);
+  const valid = await verifyPassword(password, hash);
+  assert.strictEqual(valid, true);
+});


### PR DESCRIPTION
## Summary
- add basic tests for password hashing utilities
- wire up `npm test` to use the node test runner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a5a03735c8326bd6f50c6413963a1