### PR TITLE
Fix typo in comment

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -52,7 +52,7 @@ export async function setupVite(app: Express, server: Server) {
         "index.html",
       );
 
-      // always reload the index.html file from disk incase it changes
+      // always reload the index.html file from disk in case it changes
       let template = await fs.promises.readFile(clientTemplate, "utf-8");
       template = template.replace(
         `src="/src/main.tsx"`,


### PR DESCRIPTION
## Summary
- correct a spelling mistake in `server/vite.ts`

## Testing
- `npm run check` *(fails: numerous TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a5a36e2a48326babdfae036c55374