### PR TITLE
Fix cross-site session cookie handling

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -27,7 +27,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
     saveUninitialized: false,
     cookie: {
       httpOnly: true,
-      secure: false, // Set to true in production with HTTPS
+      // Allow cross-site cookies when deployed with HTTPS
+      secure: process.env.NODE_ENV === "production",
+      sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
       maxAge: sessionTtl,
     },
   }));


### PR DESCRIPTION
## Summary
- configure session cookie for cross-site usage in production

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a68e782a88326aefe2443480f842c