### PR TITLE
fix: adjust tsconfig for bundler module resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "allowJs": true,
     "checkJs": false,
     "esModuleInterop": true,
@@ -11,6 +11,7 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
+    "jsx": "react-jsx",
     "noEmit": true,
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
## Summary
- use ESNext module with bundler resolution in tsconfig
- enable React JSX transform in TypeScript config

## Testing
- `npm run check` (fails: Property 'env' does not exist on type 'ImportMeta' and other type errors)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e9c900f788326a67278fb09535a11