### PR TITLE
feat: add health check endpoint

### DIFF
--- a/server/health.ts
+++ b/server/health.ts
@@ -1,0 +1,5 @@
+import type { Request, Response } from "express";
+
+export function healthCheck(_req: Request, res: Response) {
+  res.json({ status: "ok" });
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,6 +2,7 @@ import express, { type Request, Response, NextFunction } from "express";
 import cors from "cors";
 import { registerRoutes } from "./routes.ts";
 import { setupVite, serveStatic, log } from "./vite.ts";
+import { healthCheck } from "./health.ts";
 
 const app = express();
 
@@ -36,6 +37,8 @@ app.use((req, res, next) => {
 
   next();
 });
+
+app.get("/api/health", healthCheck);
 
 function startServer() {
   registerRoutes(app).then((server) => {

--- a/tests/health.test.ts
+++ b/tests/health.test.ts
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { healthCheck } from '../server/health.ts';
+
+test('healthCheck responds with status ok', () => {
+  let payload: any;
+  const res = {
+    json(data: any) {
+      payload = data;
+    },
+  } as any;
+
+  healthCheck({} as any, res);
+
+  assert.deepStrictEqual(payload, { status: 'ok' });
+});


### PR DESCRIPTION
## Summary
- add `/api/health` endpoint to verify server availability
- test health check handler

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_688ea1c30c6083268490a20aa5e3c336