### PR TITLE
fix: adjust server tsconfig for extension imports

### DIFF
--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -1,11 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": false,
+    "noEmit": true,
     "outDir": "dist",
-    "rootDir": "./server",
-    "module": "ESNext",
+    "rootDir": "./",
+    "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "allowImportingTsExtensions": true,
     "target": "ES2020",
     "noImplicitAny": false,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- ensure server tsconfig supports .ts extension imports by enabling `allowImportingTsExtensions` with `noEmit`
- align server build with NodeNext module resolution and root directory

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f3f451b8c8326bd10acc1509c64e5