### PR TITLE
fix: allow TS extension imports

### DIFF
--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -1,7 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": true,
+    // Only emit declaration files when compiling the backend
+    // This satisfies TypeScript's requirement for using
+    // `allowImportingTsExtensions` without disabling emission globally.
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
     "outDir": "dist",
     "rootDir": "./",
     "module": "NodeNext",


### PR DESCRIPTION
## Summary
- fix tsc config error by enabling declaration-only emits with TS extension imports

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f45b3d358832680387da8698a4a06