### PR TITLE
refactor: drop ts extensions from server imports

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,6 +1,6 @@
 import bcrypt from "bcryptjs";
-import { storage } from "./storage.ts";
-import type { User } from "@shared/schema.ts";
+import { storage } from "./storage.js";
+import type { User } from "@shared/schema.js";
 
 export async function hashPassword(password: string): Promise<string> {
   return bcrypt.hash(password, 12);

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,6 +1,6 @@
 import { Pool } from 'pg';
 import { drizzle } from 'drizzle-orm/node-postgres';
-import * as schema from "@shared/schema.ts";
+import * as schema from "@shared/schema.js";
 
 if (!process.env.DATABASE_URL) {
   throw new Error(

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,8 +1,8 @@
 import express, { type Request, Response, NextFunction } from "express";
 import cors from "cors";
-import { registerRoutes } from "./routes.ts";
-import { setupVite, serveStatic, log } from "./vite.ts";
-import { healthCheck } from "./health.ts";
+import { registerRoutes } from "./routes.js";
+import { setupVite, serveStatic, log } from "./vite.js";
+import { healthCheck } from "./health.js";
 
 const app = express();
 

--- a/server/mem-storage.ts
+++ b/server/mem-storage.ts
@@ -31,9 +31,9 @@ import {
   type InsertUserUpdate,
   type Task,
   type InsertTask,
-} from "@shared/schema.ts";
+} from "@shared/schema.js";
 
-import type { IStorage } from "./storage.impl";
+import type { IStorage } from "./storage.impl.js";
 
 function now(): Date {
   return new Date();

--- a/server/replitAuth.ts
+++ b/server/replitAuth.ts
@@ -6,7 +6,7 @@ import session from 'express-session';
 import type { Express, RequestHandler } from 'express';
 import memoize from 'memoizee';
 import connectPg from 'connect-pg-simple';
-import { storage } from './storage.ts';
+import { storage } from './storage.js';
 
 if (!process.env.REPLIT_DOMAINS) {
   throw new Error("Environment variable REPLIT_DOMAINS not provided");

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,8 +1,8 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
-import { storage } from "./storage.ts";
-import { authenticateUser, createUser } from "./auth.ts";
-import { insertDailyUpdateSchema, insertGoalSchema, insertProjectSchema, insertProjectUpdateSchema, insertUserUpdateSchema, insertTaskSchema, type Task, type Goal } from "@shared/schema.ts";
+import { storage } from "./storage.js";
+import { authenticateUser, createUser } from "./auth.js";
+import { insertDailyUpdateSchema, insertGoalSchema, insertProjectSchema, insertProjectUpdateSchema, insertUserUpdateSchema, insertTaskSchema, type Task, type Goal } from "@shared/schema.js";
 import { z } from "zod";
 import session from "express-session";
 import connectPg from "connect-pg-simple";

--- a/server/storage.db.ts
+++ b/server/storage.db.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { eq, desc, and, gte, sql } from "drizzle-orm";
-import { db } from "./db.ts";
+import { db } from "./db.js";
 import {
   users,
   teams,
@@ -32,9 +32,9 @@ import {
   type InsertUserUpdate,
   type Task,
   type InsertTask,
-} from "@shared/schema.ts";
+} from "@shared/schema.js";
 
-import type { IStorage } from "./storage.impl";
+import type { IStorage } from "./storage.impl.js";
 
 export const dbStorage: IStorage = {
   async getUser(id) {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,9 +1,9 @@
-import { IStorage } from "./storage.impl.ts";
+import type { IStorage } from "./storage.impl.js";
 
 // Dynamic import between mem and db based on NODE_ENV
 const isDev = process.env.NODE_ENV !== "production";
 
 // Use in-memory store locally, DB store in production
 export const storage: IStorage = isDev
-  ? (await import("./mem-storage.ts")).memStorage
-  : (await import("./storage.db.ts")).dbStorage;
+  ? (await import("./mem-storage.js")).memStorage
+  : (await import("./storage.db.js")).dbStorage;

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -5,7 +5,7 @@ import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
 import { fileURLToPath } from "url";
 import { nanoid } from "nanoid";
-import viteConfig from "../vite.config.ts";
+import viteConfig from "../vite.config.js";
 
 // ESM-compatible __dirname
 const __filename = fileURLToPath(import.meta.url);

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -1,9 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    // Only emit declaration files when compiling the backend
-    // This satisfies TypeScript's requirement for using
-    // `allowImportingTsExtensions` without disabling emission globally.
+    // Backend-specific compiler options
     "noEmit": false,
     "emitDeclarationOnly": false,
     "declaration": true,
@@ -11,7 +9,6 @@
     "rootDir": "./",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "allowImportingTsExtensions": true,
     "target": "ES2020",
     "noImplicitAny": false,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- use `.js` extensions for server imports
- remove `allowImportingTsExtensions` and tidy server tsconfig

## Testing
- `npx tsc --project tsconfig.server.json`
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f72f4187083268e33c5f7a8b32794