### PR TITLE
fix import path extension in tests

### DIFF
--- a/tests/health.test.ts
+++ b/tests/health.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { healthCheck } from '../server/health.ts';
+import { healthCheck } from '../server/health.js';
 
 test('healthCheck responds with status ok', () => {
   let payload: any;


### PR DESCRIPTION
## Summary
- avoid .ts extension in test imports to align with ESM NodeNext

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f7724777c8326bef0de802e328616