### PR TITLE
refactor: add explicit .js extensions for NodeNext

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,6 +1,6 @@
 import bcrypt from "bcryptjs";
-import { storage } from "./storage";
-import type { User } from "@shared/schema";
+import { storage } from "./storage.js";
+import type { User } from "../shared/schema.js";
 
 export async function hashPassword(password: string): Promise<string> {
   return bcrypt.hash(password, 12);

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,6 +1,6 @@
 import { Pool } from 'pg';
 import { drizzle } from 'drizzle-orm/node-postgres';
-import * as schema from "@shared/schema";
+import * as schema from "../shared/schema.js";
 
 if (!process.env.DATABASE_URL) {
   throw new Error(

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,8 +1,8 @@
 import express, { type Request, Response, NextFunction } from "express";
 import cors from "cors";
-import { registerRoutes } from "./routes";
-import { setupVite, serveStatic, log } from "./vite";
-import { healthCheck } from "./health";
+import { registerRoutes } from "./routes.js";
+import { setupVite, serveStatic, log } from "./vite.js";
+import { healthCheck } from "./health.js";
 
 const app = express();
 

--- a/server/mem-storage.ts
+++ b/server/mem-storage.ts
@@ -31,9 +31,9 @@ import {
   type InsertUserUpdate,
   type Task,
   type InsertTask,
-} from "@shared/schema";
+} from "../shared/schema.js";
 
-import type { IStorage } from "./storage.impl";
+import type { IStorage } from "./storage.impl.js";
 
 function now(): Date {
   return new Date();

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,8 +1,8 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
-import { storage } from "./storage";
-import { authenticateUser, createUser } from "./auth";
-import { insertDailyUpdateSchema, insertGoalSchema, insertProjectSchema, insertProjectUpdateSchema, insertUserUpdateSchema, insertTaskSchema, type Task, type Goal } from "@shared/schema";
+import { storage } from "./storage.js";
+import { authenticateUser, createUser } from "./auth.js";
+import { insertDailyUpdateSchema, insertGoalSchema, insertProjectSchema, insertProjectUpdateSchema, insertUserUpdateSchema, insertTaskSchema, type Task, type Goal } from "../shared/schema.js";
 import { z } from "zod";
 import session from "express-session";
 import connectPg from "connect-pg-simple";

--- a/server/storage.db.ts
+++ b/server/storage.db.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { eq, desc, and, gte, sql } from "drizzle-orm";
-import { db } from "./db";
+import { db } from "./db.js";
 import {
   users,
   teams,
@@ -32,9 +32,9 @@ import {
   type InsertUserUpdate,
   type Task,
   type InsertTask,
-} from "@shared/schema";
+} from "../shared/schema.js";
 
-import type { IStorage } from "./storage.impl";
+import type { IStorage } from "./storage.impl.js";
 
 export const dbStorage: IStorage = {
   async getUser(id) {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,9 +1,9 @@
-import type { IStorage } from "./storage.impl";
+import type { IStorage } from "./storage.impl.js";
 
 // Dynamic import between mem and db based on NODE_ENV
 const isDev = process.env.NODE_ENV !== "production";
 
 // Use in-memory store locally, DB store in production
 export const storage: IStorage = isDev
-  ? (await import("./mem-storage")).memStorage
-  : (await import("./storage.db")).dbStorage;
+  ? (await import("./mem-storage.js")).memStorage
+  : (await import("./storage.db.js")).dbStorage;

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -5,7 +5,7 @@ import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
 import { fileURLToPath } from "url";
 import { nanoid } from "nanoid";
-import viteConfig from "../vite.config";
+import viteConfig from "../vite.config.js";
 
 // ESM-compatible __dirname
 const __filename = fileURLToPath(import.meta.url);


### PR DESCRIPTION
## Summary
- fix server build by adding .js extensions to TypeScript imports for NodeNext
- replace shared schema path alias with relative imports

## Testing
- `npx tsc -p tsconfig.server.json`
- `npm test`
- `npm run build:server`


------
https://chatgpt.com/codex/tasks/task_e_688f7def65c88326abd996aac79ca650